### PR TITLE
[PULL REQUEST] - Update Prisma client generation in CI workflow

### DIFF
--- a/.github/workflows/api-build.yml
+++ b/.github/workflows/api-build.yml
@@ -27,10 +27,15 @@ jobs:
       - name: Install dependencies
         run: pnpm install --filter=./apps/api...
 
-      - name: Generate Prisma client
+      - name: Generate Prisma master client
         env:
           DATABASE_URL: postgresql://user:password@localhost:5432/dummy
-        run: pnpm --filter=./apps/api... run prisma:generate
+        run: pnpm --filter=./apps/api... run prisma:generate:master
+
+      - name: Generate Prisma tenant client
+        env:
+          DATABASE_TENANT_URL: postgresql://user:password@localhost:5432/dummy
+        run: pnpm --filter=./apps/api... run prisma:generate:tenant
 
       - name: Lint code
         run: pnpm lint --filter=./apps/api...


### PR DESCRIPTION
- Renamed the Prisma client generation step to clarify it generates the master client.
- Added a new step to generate the tenant Prisma client with a separate environment variable for the tenant database URL.

Closes the following issues:
- [https://github.com/sisques-labs/saas-boilerplate/issues/107](https://github.com/sisques-labs/saas-boilerplate/issues/107)